### PR TITLE
Add missing return in timeInCurrentState

### DIFF
--- a/firmware/FiniteStateMachine.cpp
+++ b/firmware/FiniteStateMachine.cpp
@@ -118,6 +118,6 @@ boolean FiniteStateMachine::isInState( State &state ) const {
 }
 
 unsigned long FiniteStateMachine::timeInCurrentState() {
-	millis() - stateChangeTime;
+	return millis() - stateChangeTime;
 }
 //END FINITE STATE MACHINE


### PR DESCRIPTION
Fix `no return statement in function` compiler error
