### PR TITLE
Add typed state machine variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ Check if state is equal to the current state of the FSM
 
 ---
 
+## Typed States
+
+To avoid mistakes mixing states from different states machines together, use the strongly typed state variant. The compiler will throw an error if you mix states.
+
+Use `DECLARE_STATE` to create a named `State` class for each of your state machines and pass that class when creating the state machine. All the methods of the named `State` class and the typed state machine `FSMT` are the same as the generic variant of `State` and `FSM`.
+
+_FiniteStateMachineTyped<StateType>(StateType& current)_
+
+_FSMT<StateType>(StateType& current)_
+
+Example:
+
+```
+DECLARE_STATE(ConnectivityState);
+ConnectivityState disconnectedState(waitForConnection);
+ConnectivityState connectedState(waitForDisconnection);
+FSMT<ConnectivityState> connectivityStateMachine(disconnectedState);
+
+// Assuming brewCoffeState is a CoffeeState from a different state machine this would fail with a compiler error
+connectivityStateMachine.transitionTo(brewCoffeState);
+// error: no matching function for call to 'FiniteStateMachineTyped<ConnectivityState>::transitionTo(CoffeeState&)'
+```
+
 # Example
 
 ## LED Finite State Machine

--- a/examples/typed/typed.cpp
+++ b/examples/typed/typed.cpp
@@ -1,0 +1,48 @@
+#include <FiniteStateMachine.h>
+
+DECLARE_STATE(CatState);
+void restCat();
+CatState catRestingState(restCat);
+void meow();
+CatState meowingState(meow);
+FSMT<CatState> catFSM(catRestingState);
+
+DECLARE_STATE(DogState);
+void restDog();
+DogState dogRestingState(restDog);
+void bark();
+DogState barkingState(bark);
+FSMT<DogState> dogFSM(dogRestingState);
+
+// setting the initial state to a cat state would fail with the compiler error
+// no known conversion for argument 1 from 'CatState' to 'DogState&'
+// FSMT<DogState> dogFSM(catRestingState);
+
+void setup() {
+}
+
+void loop() {
+  catFSM.update();
+  dogFSM.update();
+}
+
+void restCat() {
+  catFSM.transitionTo(meowingState);
+}
+
+void meow() {
+  // meow!
+  catFSM.transitionTo(catRestingState);
+}
+
+void restDog() {
+  dogFSM.transitionTo(barkingState);
+  // either asking the cat to bark or the dog to meow would fail with a compiler error
+  // catFSM.transitionTo(barkingState);
+  // dogFSM.transitionTo(meowingState);
+}
+
+void bark() {
+  // bark!
+  dogFSM.transitionTo(dogRestingState);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=FiniteStateMachine
-version=1.8.1
+version=1.9.0
 license=GNU General Public License, version 2
 author=Gustavo Gonnet <gusgonnet@gmail.com>
 sentence=A simple Finite State Machine Library

--- a/src/FiniteStateMachine.cpp
+++ b/src/FiniteStateMachine.cpp
@@ -1,7 +1,7 @@
 /*
 ||
 || @file FiniteStateMachine.cpp
-|| @version 1.8
+|| @version 1.9
 || @original author Alexander Brevig
 || @contact alexanderbrevig@gmail.com
 || @Ported to Particle by Gustavo Gonnet

--- a/src/FiniteStateMachine.h
+++ b/src/FiniteStateMachine.h
@@ -1,7 +1,7 @@
 /*
 ||
 || @file FiniteStateMachine.h
-|| @version 1.8.1
+|| @version 1.9.0
 || @original author Alexander Brevig
 || @contact alexanderbrevig@gmail.com
 || @Ported to Particle by Gustavo Gonnet
@@ -12,6 +12,7 @@
 || #
 ||
 || @changelog
+|| | 1.9.0 2019-11-03- Julien Vanier : Add strongly typed variant
 || | 1.8.1 2016-01-07- Gustavo Gonnet : Pull request from Julien Vanier
 || | 1.8.0 2016-01-07- Gustavo Gonnet : Ported to Particle
 || | 1.7 2010-03-08- Alexander Brevig : Fixed a bug, constructor ran update, thanks to Ren? Press?
@@ -108,6 +109,51 @@ class FiniteStateMachine {
 		State* 	currentState;
 		State* 	nextState;
 		unsigned long stateChangeTime;
+};
+
+// Strongly typed variant
+
+#define DECLARE_STATE(StateT) \
+	class StateT : public State { \
+		public: \
+			StateT( void (*updateFunction)() ) \
+				: State(updateFunction) {} \
+			StateT( void (*enterFunction)(), void (*updateFunction)(), void (*exitFunction)() ) \
+				: State(enterFunction, updateFunction, exitFunction) {} \
+	}
+
+
+#define FSMT FiniteStateMachineTyped
+
+template <class StateT>
+class FiniteStateMachineTyped {
+	public:
+		FiniteStateMachineTyped(StateT& current)
+			: stateMachine(current) {}
+
+		FiniteStateMachineTyped& update() {
+			return (FiniteStateMachineTyped&)stateMachine.update();
+		}
+		FiniteStateMachineTyped& transitionTo( StateT& state ) {
+			return (FiniteStateMachineTyped&)stateMachine.transitionTo(state);
+		}
+		FiniteStateMachineTyped& immediateTransitionTo( StateT& state ) {
+			return (FiniteStateMachineTyped&)stateMachine.immediateTransitionTo(state);
+		}
+
+		StateT& getCurrentState() {
+			return (StateT&)stateMachine.getCurrentState();
+		}
+		boolean isInState( StateT &state ) const {
+			return stateMachine.isInState(state);
+		}
+
+		unsigned long timeInCurrentState() {
+			return stateMachine.timeInCurrentState();
+		}
+
+	private:
+		FiniteStateMachine stateMachine;
 };
 
 #endif


### PR DESCRIPTION
I made a mistake transitioning a state machine to a state that belonged to a different state machine and the code compiled and ran. These kinds of mistakes could be easier to catch using the compiler using typed states.

Here's an example of the interfaces I implemented:
```
DECLARE_STATE(ConnectivityState);
ConnectivityState disconnectedState(waitForConnection);
ConnectivityState connectedState(waitForDisconnection);
FSMT<ConnectivityState> connectivityStateMachine(disconnectedState);

// Assuming brewCoffeState is a CoffeeState from a different state machine this would fail with a compiler error
connectivityStateMachine.transitionTo(brewCoffeState);
// error: no matching function for call to 'FiniteStateMachineTyped<ConnectivityState>::transitionTo(CoffeeState&)'
```